### PR TITLE
sql: support COMMENT ON FUNCTION, PROCEDURE, and ROUTINE

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1609,6 +1609,11 @@ func (tc *Collection) GetTypeComment(typeID descpb.ID) (comment string, ok bool)
 	return tc.GetComment(catalogkeys.MakeCommentKey(uint32(typeID), 0, catalogkeys.TypeCommentType))
 }
 
+// GetFunctionComment implements the scdecomp.CommentGetter interface.
+func (tc *Collection) GetFunctionComment(funcID descpb.ID) (comment string, ok bool) {
+	return tc.GetComment(catalogkeys.MakeCommentKey(uint32(funcID), 0, catalogkeys.FunctionCommentType))
+}
+
 // GetColumnComment implements the scdecomp.CommentGetter interface.
 func (tc *Collection) GetColumnComment(
 	tableID descpb.ID, pgAttrNum catid.PGAttributeNum,

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6061,6 +6061,12 @@ var crdbInternalCatalogCommentsTable = virtualSchemaTable{
 				classOid = tree.NewDOid(catconstants.PgCatalogTypeTableID)
 				objOid = tree.NewDOid(oid.Oid(key.ObjectID))
 
+			case catalogkeys.FunctionCommentType:
+				// Functions live in pg_proc; their OIDs are descriptor IDs offset
+				// by oidext.CockroachPredefinedOIDMax (see catid.FuncIDToOID).
+				classOid = tree.NewDOid(catconstants.PgCatalogProcTableID)
+				objOid = tree.NewDOid(catid.FuncIDToOID(descpb.ID(key.ObjectID)))
+
 			case catalogkeys.ColumnCommentType, catalogkeys.TableCommentType:
 				classOid = tree.NewDOid(catconstants.PgCatalogClassTableID)
 				objOid = tree.NewDOid(oid.Oid(key.ObjectID))

--- a/pkg/sql/logictest/testdata/logic_test/comment_on
+++ b/pkg/sql/logictest/testdata/logic_test/comment_on
@@ -782,3 +782,179 @@ statement ok
 DROP SEQUENCE comment_seq
 
 subtest end
+
+# Tests for COMMENT ON FUNCTION / PROCEDURE / ROUTINE (issue #44135).
+# Declarative-only, mirroring COMMENT ON TYPE. Functions get their own
+# scpb.FunctionComment element and the catalogkeys.FunctionCommentType (6)
+# storage. Privilege model is ownership, matching PG and matching how
+# DROP/ALTER FUNCTION already gate.
+subtest comment_on_function_and_procedure
+
+statement ok
+CREATE FUNCTION fn_comment_int(x INT) RETURNS INT LANGUAGE SQL AS 'SELECT x'
+
+statement ok
+CREATE FUNCTION fn_comment_str(x STRING) RETURNS STRING LANGUAGE SQL AS 'SELECT x'
+
+statement ok
+CREATE PROCEDURE proc_comment(x INT) LANGUAGE SQL AS 'SELECT 1'
+
+# Legacy schema changer rejects all three keywords with kind-specific errors.
+onlyif config local-legacy-schema-changer
+statement error COMMENT ON FUNCTION is only implemented in the declarative schema changer
+COMMENT ON FUNCTION fn_comment_int(INT) IS 'fn_legacy'
+
+onlyif config local-legacy-schema-changer
+statement error COMMENT ON PROCEDURE is only implemented in the declarative schema changer
+COMMENT ON PROCEDURE proc_comment(INT) IS 'proc_legacy'
+
+onlyif config local-legacy-schema-changer
+statement error COMMENT ON ROUTINE is only implemented in the declarative schema changer
+COMMENT ON ROUTINE fn_comment_int(INT) IS 'routine_legacy'
+
+# Declarative path: each keyword sets a comment.
+skipif config local-legacy-schema-changer
+statement ok
+COMMENT ON FUNCTION fn_comment_int(INT) IS 'fn_int_v1'
+
+skipif config local-legacy-schema-changer
+statement ok
+COMMENT ON PROCEDURE proc_comment(INT) IS 'proc_v1'
+
+skipif config local-legacy-schema-changer
+statement ok
+COMMENT ON ROUTINE fn_comment_str(STRING) IS 'fn_str_via_routine'
+
+# Comments are stored with type=6 (FunctionCommentType) keyed by the
+# routine's descriptor ID. Function OIDs are descriptor IDs offset by the
+# CockroachPredefinedOIDMax (100000) so we subtract that to compare.
+skipif config local-legacy-schema-changer
+query IT rowsort
+SELECT type, comment
+  FROM system.comments
+ WHERE type = 6
+   AND object_id IN (
+     'fn_comment_int(INT)'::regprocedure::oid::int - 100000,
+     'fn_comment_str(STRING)'::regprocedure::oid::int - 100000,
+     'proc_comment(INT)'::regprocedure::oid::int - 100000)
+----
+6  fn_int_v1
+6  fn_str_via_routine
+6  proc_v1
+
+# Comments surface via obj_description(oid, 'pg_proc').
+skipif config local-legacy-schema-changer
+query T
+SELECT obj_description('fn_comment_int(INT)'::regprocedure::oid, 'pg_proc')
+----
+fn_int_v1
+
+skipif config local-legacy-schema-changer
+query T
+SELECT obj_description('proc_comment(INT)'::regprocedure::oid, 'pg_proc')
+----
+proc_v1
+
+# Overwriting an existing comment.
+skipif config local-legacy-schema-changer
+statement ok
+COMMENT ON FUNCTION fn_comment_int(INT) IS 'fn_int_v2'
+
+skipif config local-legacy-schema-changer
+query T
+SELECT obj_description('fn_comment_int(INT)'::regprocedure::oid, 'pg_proc')
+----
+fn_int_v2
+
+# Setting comment to NULL removes it.
+skipif config local-legacy-schema-changer
+statement ok
+COMMENT ON FUNCTION fn_comment_int(INT) IS NULL
+
+skipif config local-legacy-schema-changer
+query I
+SELECT count(*) FROM system.comments
+ WHERE type = 6
+   AND object_id = 'fn_comment_int(INT)'::regprocedure::oid::int - 100000
+----
+0
+
+# Re-set so the DROP cleanup test below has something to clean up.
+skipif config local-legacy-schema-changer
+statement ok
+COMMENT ON FUNCTION fn_comment_int(INT) IS 'fn_int_v3'
+
+# Wrong-kind: COMMENT ON FUNCTION on a procedure errors, and vice versa.
+# ResolveRoutine surfaces this as "X(args) is not a function/procedure".
+skipif config local-legacy-schema-changer
+statement error proc_comment\(int\) is not a function
+COMMENT ON FUNCTION proc_comment(INT) IS 'oops'
+
+skipif config local-legacy-schema-changer
+statement error fn_comment_int\(int\) is not a procedure
+COMMENT ON PROCEDURE fn_comment_int(INT) IS 'oops'
+
+# COMMENT ON ROUTINE accepts either kind.
+skipif config local-legacy-schema-changer
+statement ok
+COMMENT ON ROUTINE proc_comment(INT) IS 'proc_via_routine'
+
+skipif config local-legacy-schema-changer
+query T
+SELECT obj_description('proc_comment(INT)'::regprocedure::oid, 'pg_proc')
+----
+proc_via_routine
+
+# Builtin functions are off-limits for COMMENT ON writes. ResolveRoutine's
+# RoutineType filter excludes BuiltinRoutine, so the failure mode is
+# "is not a function/procedure" rather than the panic message — either way
+# the write is rejected.
+skipif config local-legacy-schema-changer
+statement error length\(string\) is not a function
+COMMENT ON FUNCTION length(STRING) IS 'oops'
+
+skipif config local-legacy-schema-changer
+statement error length\(string\) is not a procedure
+COMMENT ON PROCEDURE length(STRING) IS 'oops'
+
+skipif config local-legacy-schema-changer
+statement error length\(string\) is not a function
+COMMENT ON ROUTINE length(STRING) IS 'oops'
+
+# Builtin descriptions remain readable through obj_description, populated
+# by crdb_internal.kv_builtin_function_comments. Pick a stable builtin
+# whose Info string isn't expected to change. crdb_internal.cluster_id is
+# a no-arg builtin with a stable description.
+skipif config local-legacy-schema-changer
+query B
+SELECT obj_description('crdb_internal.cluster_id()'::regprocedure::oid, 'pg_proc') IS NOT NULL
+----
+true
+
+# DROP FUNCTION removes the comment from system.comments via the scdecomp
+# wiring (FunctionComment element gets dropped when the parent Function
+# element is dropped).
+skipif config local-legacy-schema-changer
+statement ok
+DROP FUNCTION fn_comment_int(INT)
+
+skipif config local-legacy-schema-changer
+query I
+SELECT count(*) FROM system.comments WHERE type = 6 AND comment = 'fn_int_v3'
+----
+0
+
+# Cleanup.
+skipif config local-legacy-schema-changer
+statement ok
+DROP FUNCTION fn_comment_str(STRING);
+DROP PROCEDURE proc_comment(INT)
+
+# Final invalid_objects check: the comment-on-routine plumbing should not
+# leave dangling system.comments rows.
+skipif config local-legacy-schema-changer
+query ITTTT
+SELECT * FROM "".crdb_internal.invalid_objects WHERE error LIKE '%FunctionCommentType%' OR error LIKE '%type 6%'
+----
+
+subtest end

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -170,6 +170,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.CommentOnDatabase(ctx, n)
 	case *tree.CommentOnIndex:
 		return p.CommentOnIndex(ctx, n)
+	case *tree.CommentOnRoutine:
+		return p.CommentOnRoutine(ctx, n)
 	case *tree.CommentOnSchema:
 		return p.CommentOnSchema(ctx, n)
 	case *tree.CommentOnSequence:
@@ -409,6 +411,7 @@ func init() {
 		&tree.CommentOnConstraint{},
 		&tree.CommentOnDatabase{},
 		&tree.CommentOnIndex{},
+		&tree.CommentOnRoutine{},
 		&tree.CommentOnSchema{},
 		&tree.CommentOnSequence{},
 		&tree.CommentOnTable{},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1096,7 +1096,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %token <str> REGCLASS REGION REGIONAL REGIONS REGNAMESPACE REGPROC REGPROCEDURE REGROLE REGTYPE REINDEX
 %token <str> RELATIVE RELOCATE REMOVE_PATH REMOVE_REGIONS RENAME REPEATABLE REPLACE REPLICATED REPLICATION
 %token <str> RELEASE RESET RESOLVED RESOURCE RESTART RESTORE RESTRICT RESTRICTED RESTRICTIVE RESUME RETENTION RETURNING RETURN RETURNS REVISION REVISION_HISTORY
-%token <str> REVOKE RIGHT ROLE ROLES ROLLBACK ROLLUP ROUTINES ROW ROWS RSHIFT RULE RUN RUNNING
+%token <str> REVOKE RIGHT ROLE ROLES ROLLBACK ROLLUP ROUTINE ROUTINES ROW ROWS RSHIFT RULE RUN RUNNING
 
 %token <str> SAVEPOINT SCANS SCATTER SCHEDULE SCHEDULES SCROLL SCHEMA SCHEMA_ONLY SCHEMAS SCRUB
 %token <str> SEARCH SECOND SECONDARY SECURITY SECURITY_INVOKER SELECT SEQUENCE SEQUENCES
@@ -5136,7 +5136,18 @@ comment_stmt:
     $$.val = &tree.CommentOnConstraint{Constraint:tree.Name($4), Table: $6.unresolvedObjectName(), Comment: $8.strPtr()}
   }
 | COMMENT ON EXTENSION error { return unimplementedWithIssueDetail(sqllex, 74777, "comment on extension") }
-| COMMENT ON FUNCTION error { return unimplementedWithIssueDetail(sqllex, 44135, "comment on function") }
+| COMMENT ON FUNCTION function_with_paramtypes IS comment_text
+  {
+    $$.val = &tree.CommentOnRoutine{Routine: $4.functionObj(), RoutineType: tree.UDFRoutine, Comment: $6.strPtr()}
+  }
+| COMMENT ON PROCEDURE function_with_paramtypes IS comment_text
+  {
+    $$.val = &tree.CommentOnRoutine{Routine: $4.functionObj(), RoutineType: tree.ProcedureRoutine, Comment: $6.strPtr()}
+  }
+| COMMENT ON ROUTINE function_with_paramtypes IS comment_text
+  {
+    $$.val = &tree.CommentOnRoutine{Routine: $4.functionObj(), RoutineType: tree.UDFRoutine | tree.ProcedureRoutine, Comment: $6.strPtr()}
+  }
 
 comment_text:
   SCONST
@@ -19796,6 +19807,7 @@ unreserved_keyword:
 | ROLES
 | ROLLBACK
 | ROLLUP
+| ROUTINE
 | ROUTINES
 | ROWS
 | RULE
@@ -20401,6 +20413,7 @@ bare_label_keywords:
 | ROLES
 | ROLLBACK
 | ROLLUP
+| ROUTINE
 | ROUTINES
 | ROW
 | ROWS

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/comment_on.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/comment_on.go
@@ -22,6 +22,15 @@ var commentResolveParams = ResolveParams{
 	RequiredPrivilege:   privilege.CREATE,
 }
 
+// ownerCommentResolveParams is used by COMMENT ON statements that gate on
+// ownership rather than CREATE — currently only COMMENT ON
+// FUNCTION/PROCEDURE/ROUTINE, since functions have no per-object CREATE
+// privilege and PG requires the routine owner.
+var ownerCommentResolveParams = ResolveParams{
+	IsExistenceOptional: false,
+	RequireOwnership:    true,
+}
+
 // CommentOnDatabase implements COMMENT ON DATABASE xxx IS xxx statement.
 func CommentOnDatabase(b BuildCtx, statement *tree.CommentOnDatabase) {
 	elements := b.ResolveDatabase(statement.Name, commentResolveParams)
@@ -157,6 +166,24 @@ func CommentOnIndex(b BuildCtx, statement *tree.CommentOnIndex) {
 	}
 }
 
+// CommentOnRoutine implements COMMENT ON FUNCTION, COMMENT ON PROCEDURE,
+// and COMMENT ON ROUTINE. ResolveRoutine enforces the kind filter encoded
+// in statement.RoutineType, panics on builtins, and resolves overloads
+// from the optional argument list.
+func CommentOnRoutine(b BuildCtx, statement *tree.CommentOnRoutine) {
+	fnElements := b.ResolveRoutine(&statement.Routine, ownerCommentResolveParams, statement.RoutineType)
+	fn := fnElements.FilterFunction().MustGetOneElement()
+
+	if statement.Comment == nil {
+		if existing := fnElements.FilterFunctionComment().MustGetZeroOrOneElement(); existing != nil {
+			b.Drop(existing)
+			b.LogEventForExistingTarget(existing)
+		}
+		return
+	}
+	addComment(b, fnElements, &scpb.FunctionComment{FunctionID: fn.FunctionID, Comment: *statement.Comment})
+}
+
 // CommentOnConstraint implements COMMENT ON CONSTRAINT xxx ON table_name IS xxx
 // statement.
 func CommentOnConstraint(b BuildCtx, statement *tree.CommentOnConstraint) {
@@ -175,7 +202,8 @@ func dropComment(b BuildCtx, elements *scpb.ElementCollection[scpb.Element]) {
 	elements.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
 		switch e.(type) {
 		case *scpb.DatabaseComment, *scpb.SchemaComment, *scpb.IndexComment,
-			*scpb.ConstraintComment, *scpb.ColumnComment, *scpb.TypeComment:
+			*scpb.ConstraintComment, *scpb.ColumnComment, *scpb.TypeComment,
+			*scpb.FunctionComment:
 			b.Drop(e)
 			b.LogEventForExistingTarget(e)
 		}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -53,6 +53,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.CommentOnConstraint)(nil)): {fn: CommentOnConstraint, statementTags: []string{tree.CommentOnConstraintTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CommentOnDatabase)(nil)):   {fn: CommentOnDatabase, statementTags: []string{tree.CommentOnDatabaseTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CommentOnIndex)(nil)):      {fn: CommentOnIndex, statementTags: []string{tree.CommentOnIndexTag}, on: true, checks: nil},
+	reflect.TypeOf((*tree.CommentOnRoutine)(nil)):    {fn: CommentOnRoutine, statementTags: []string{tree.CommentOnFunctionTag, tree.CommentOnProcedureTag, tree.CommentOnRoutineTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CommentOnSchema)(nil)):     {fn: CommentOnSchema, statementTags: []string{tree.CommentOnSchemaTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CommentOnSequence)(nil)):   {fn: CommentOnSequence, statementTags: []string{tree.CommentOnSequenceTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CommentOnTable)(nil)):      {fn: CommentOnTable, statementTags: []string{tree.CommentOnTableTag}, on: true, checks: nil},

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -1196,6 +1196,14 @@ func (w *walkCtx) walkFunction(fnDesc catalog.FunctionDescriptor) {
 			Params:     fn.Params,
 		})
 	}
+	if w.clusterVersion.IsActive(clusterversion.V26_3) {
+		if comment, ok := w.commentReader.GetFunctionComment(fnDesc.GetID()); ok {
+			w.ev(scpb.Status_PUBLIC, &scpb.FunctionComment{
+				FunctionID: fnDesc.GetID(),
+				Comment:    comment,
+			})
+		}
+	}
 
 	fnBody := &scpb.FunctionBody{
 		FunctionID:  fnDesc.GetID(),

--- a/pkg/sql/schemachanger/scdecomp/dependencies.go
+++ b/pkg/sql/schemachanger/scdecomp/dependencies.go
@@ -32,6 +32,10 @@ type CommentGetter interface {
 	// comment actually exists or not.
 	GetTypeComment(TypeID catid.DescID) (comment string, ok bool)
 
+	// GetFunctionComment returns the comment for a function (or procedure). `ok`
+	// returned indicates if the comment actually exists or not.
+	GetFunctionComment(funcID catid.DescID) (comment string, ok bool)
+
 	// GetColumnComment returns comment for a column. `ok` returned indicates if
 	// the comment actually exists or not.
 	GetColumnComment(tableID catid.DescID, pgAttrNum catid.PGAttributeNum) (comment string, ok bool)

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1519,6 +1519,11 @@ func (s *TestState) GetTypeComment(typeID catid.DescID) (comment string, ok bool
 	return s.get(typeID, 0, catalogkeys.TypeCommentType)
 }
 
+// GetFunctionComment implements the scdecomp.CommentGetter interface.
+func (s *TestState) GetFunctionComment(funcID catid.DescID) (comment string, ok bool) {
+	return s.get(funcID, 0, catalogkeys.FunctionCommentType)
+}
+
 // GetColumnComment implements the scdecomp.CommentGetter interface.
 func (s *TestState) GetColumnComment(
 	tableID catid.DescID, pgAttrNum catid.PGAttributeNum,

--- a/pkg/sql/schemachanger/scexec/scmutationexec/comment.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/comment.go
@@ -36,6 +36,13 @@ func (i *immediateVisitor) UpsertTypeComment(_ context.Context, op scop.UpsertTy
 	return nil
 }
 
+func (i *immediateVisitor) UpsertFunctionComment(
+	_ context.Context, op scop.UpsertFunctionComment,
+) error {
+	i.AddComment(op.FunctionID, 0, catalogkeys.FunctionCommentType, op.Comment)
+	return nil
+}
+
 func (i *immediateVisitor) UpsertColumnComment(
 	_ context.Context, op scop.UpsertColumnComment,
 ) error {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/drop.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/drop.go
@@ -79,6 +79,13 @@ func (i *immediateVisitor) RemoveTypeComment(_ context.Context, op scop.RemoveTy
 	return nil
 }
 
+func (i *immediateVisitor) RemoveFunctionComment(
+	_ context.Context, op scop.RemoveFunctionComment,
+) error {
+	i.DeleteComment(op.FunctionID, 0, catalogkeys.FunctionCommentType)
+	return nil
+}
+
 func (i *immediateVisitor) RemoveDatabaseComment(
 	_ context.Context, op scop.RemoveDatabaseComment,
 ) error {

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -904,6 +904,22 @@ type RemoveTypeComment struct {
 	TypeID descpb.ID
 }
 
+// UpsertFunctionComment is used to add a comment to a function (or
+// procedure). Functions and procedures share descriptor space, so a single
+// op covers both.
+type UpsertFunctionComment struct {
+	immediateMutationOp
+	FunctionID descpb.ID
+	Comment    string
+}
+
+// RemoveFunctionComment is used to delete a comment associated with a
+// function (or procedure).
+type RemoveFunctionComment struct {
+	immediateMutationOp
+	FunctionID descpb.ID
+}
+
 // UpsertDatabaseComment is used to add a comment to a database.
 type UpsertDatabaseComment struct {
 	immediateMutationOp

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -130,6 +130,8 @@ type ImmediateMutationVisitor interface {
 	RemoveTableComment(context.Context, RemoveTableComment) error
 	UpsertTypeComment(context.Context, UpsertTypeComment) error
 	RemoveTypeComment(context.Context, RemoveTypeComment) error
+	UpsertFunctionComment(context.Context, UpsertFunctionComment) error
+	RemoveFunctionComment(context.Context, RemoveFunctionComment) error
 	UpsertDatabaseComment(context.Context, UpsertDatabaseComment) error
 	RemoveDatabaseComment(context.Context, RemoveDatabaseComment) error
 	UpsertSchemaComment(context.Context, UpsertSchemaComment) error
@@ -758,6 +760,16 @@ func (op UpsertTypeComment) Visit(ctx context.Context, v ImmediateMutationVisito
 // Visit is part of the ImmediateMutationOp interface.
 func (op RemoveTypeComment) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.RemoveTypeComment(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op UpsertFunctionComment) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.UpsertFunctionComment(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op RemoveFunctionComment) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.RemoveFunctionComment(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -166,6 +166,7 @@ message ElementProto {
     FunctionBody function_body = 164 [(gogoproto.moretags) = "parent:\"Function\""];
     FunctionSecurity function_security = 165 [(gogoproto.moretags) = "parent:\"Function\""];
     FunctionParams function_params = 166 [(gogoproto.moretags) = "parent:\"Function\""];
+    FunctionComment function_comment = 167 [(gogoproto.moretags) = "parent:\"Function\""];
 
     // Domain type elements.
     DomainDefault domain_default = 250 [(gogoproto.moretags) = "parent:\"DomainType\""];
@@ -851,6 +852,11 @@ message TableComment {
 
 message TypeComment {
   uint32 type_id = 1 [(gogoproto.customname) = "TypeID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+  string comment = 2;
+}
+
+message FunctionComment {
+  uint32 function_id = 1 [(gogoproto.customname) = "FunctionID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   string comment = 2;
 }
 

--- a/pkg/sql/schemachanger/scpb/elements_generated.go
+++ b/pkg/sql/schemachanger/scpb/elements_generated.go
@@ -1379,6 +1379,43 @@ func (c *ElementCollection[E]) FilterFunctionBody() *ElementCollection[*Function
 	return (*ElementCollection[*FunctionBody])(ret)
 }
 
+func (e FunctionComment) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_FunctionComment) Element() Element {
+	return e.FunctionComment
+}
+
+// ForEachFunctionComment iterates over elements of type FunctionComment.
+// Deprecated
+func ForEachFunctionComment(
+	c *ElementCollection[Element], fn func(current Status, target TargetStatus, e *FunctionComment),
+) {
+  c.FilterFunctionComment().ForEach(fn)
+}
+
+// FindFunctionComment finds the first element of type FunctionComment.
+// Deprecated
+func FindFunctionComment(
+	c *ElementCollection[Element],
+) (current Status, target TargetStatus, element *FunctionComment) {
+	if tc := c.FilterFunctionComment(); !tc.IsEmpty() {
+		var e Element
+		current, target, e = tc.Get(0)
+		element = e.(*FunctionComment)
+	}
+	return current, target, element
+}
+
+// FunctionCommentElements filters elements of type FunctionComment.
+func (c *ElementCollection[E]) FilterFunctionComment() *ElementCollection[*FunctionComment] {
+	ret := c.genericFilter(func(_ Status, _ TargetStatus, e Element) bool {
+		_, ok := e.(*FunctionComment)
+		return ok
+	})
+	return (*ElementCollection[*FunctionComment])(ret)
+}
+
 func (e FunctionLeakProof) element() {}
 
 // Element implements ElementGetter.
@@ -3789,6 +3826,8 @@ func (e* ElementProto) SetElement(element Element) {
 			e.ElementOneOf = &ElementProto_Function{ Function: t}
 		case *FunctionBody:
 			e.ElementOneOf = &ElementProto_FunctionBody{ FunctionBody: t}
+		case *FunctionComment:
+			e.ElementOneOf = &ElementProto_FunctionComment{ FunctionComment: t}
 		case *FunctionLeakProof:
 			e.ElementOneOf = &ElementProto_FunctionLeakProof{ FunctionLeakProof: t}
 		case *FunctionName:
@@ -3958,6 +3997,7 @@ func GetElementOneOfProtos() []interface{} {
 	((*ElementProto_ForeignKeyConstraintUnvalidated)(nil)),
 	((*ElementProto_Function)(nil)),
 	((*ElementProto_FunctionBody)(nil)),
+	((*ElementProto_FunctionComment)(nil)),
 	((*ElementProto_FunctionLeakProof)(nil)),
 	((*ElementProto_FunctionName)(nil)),
 	((*ElementProto_FunctionNullInputBehavior)(nil)),
@@ -4065,6 +4105,7 @@ func GetElementTypes() []interface{} {
 	((*ForeignKeyConstraintUnvalidated)(nil)),
 	((*Function)(nil)),
 	((*FunctionBody)(nil)),
+	((*FunctionComment)(nil)),
 	((*FunctionLeakProof)(nil)),
 	((*FunctionName)(nil)),
 	((*FunctionNullInputBehavior)(nil)),

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -241,6 +241,11 @@ FunctionBody : []UsesSequenceIDs
 FunctionBody : []UsesTypeIDs
 FunctionBody : []UsesFunctionIDs
 
+object FunctionComment
+
+FunctionComment :  FunctionID
+FunctionComment :  Comment
+
 object FunctionLeakProof
 
 FunctionLeakProof :  FunctionID
@@ -670,6 +675,7 @@ EnumType <|-- EnumTypeValue
 Table <|-- ForeignKeyConstraint
 Table <|-- ForeignKeyConstraintUnvalidated
 Function <|-- FunctionBody
+Function <|-- FunctionComment
 Function <|-- FunctionLeakProof
 Function <|-- FunctionName
 Function <|-- FunctionNullInputBehavior

--- a/pkg/sql/schemachanger/scplan/internal/opgen/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "opgen_foreign_key_constraint_unvalidated.go",
         "opgen_function.go",
         "opgen_function_body.go",
+        "opgen_function_comment.go",
         "opgen_function_leakproof.go",
         "opgen_function_name.go",
         "opgen_function_null_input.go",

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_function_comment.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_function_comment.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package opgen
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+)
+
+func init() {
+	opRegistry.register((*scpb.FunctionComment)(nil),
+		toPublic(
+			scpb.Status_ABSENT,
+			to(scpb.Status_PUBLIC,
+				emit(func(this *scpb.FunctionComment) *scop.UpsertFunctionComment {
+					return &scop.UpsertFunctionComment{
+						FunctionID: this.FunctionID,
+						Comment:    this.Comment,
+					}
+				}),
+			),
+		),
+		toAbsent(
+			scpb.Status_PUBLIC,
+			to(scpb.Status_ABSENT,
+				emit(func(this *scpb.FunctionComment) *scop.RemoveFunctionComment {
+					return &scop.RemoveFunctionComment{
+						FunctionID: this.FunctionID,
+					}
+				}),
+			),
+		),
+	)
+}

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -590,6 +590,10 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.FunctionParams)(nil)),
 		rel.EntityAttr(DescID, "FunctionID"),
 	),
+	rel.EntityMapping(t((*scpb.FunctionComment)(nil)),
+		rel.EntityAttr(DescID, "FunctionID"),
+		rel.EntityAttr(Value, "Comment"),
+	),
 	// Domain constraint elements are placed at the end to avoid introducing
 	// new attribute ordinals before existing ones, which would change the
 	// field order in element string formatting across all golden files.

--- a/pkg/sql/schemachanger/screl/scalars.go
+++ b/pkg/sql/schemachanger/screl/scalars.go
@@ -146,7 +146,7 @@ func VersionSupportsElementUse(el scpb.Element, version clusterversion.ClusterVe
 		return version.IsActive(clusterversion.V26_2)
 	case *scpb.DomainType, *scpb.EnumTypeValue, *scpb.DomainDefault, *scpb.DomainNotNull,
 		*scpb.DomainCheckConstraint, *scpb.DomainCheckConstraintUnvalidated,
-		*scpb.DomainConstraintName:
+		*scpb.DomainConstraintName, *scpb.FunctionComment:
 		return version.IsActive(clusterversion.V26_3)
 	default:
 		panic(errors.AssertionFailedf("unknown element %T", el))

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "comment_on_constraint.go",
         "comment_on_database.go",
         "comment_on_index.go",
+        "comment_on_routine.go",
         "comment_on_schema.go",
         "comment_on_sequence.go",
         "comment_on_table.go",

--- a/pkg/sql/sem/tree/comment_on_routine.go
+++ b/pkg/sql/sem/tree/comment_on_routine.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tree
+
+import "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+
+// CommentOnRoutine represents a COMMENT ON FUNCTION, COMMENT ON PROCEDURE,
+// or COMMENT ON ROUTINE statement. The keyword the user wrote is captured
+// by RoutineType: a single bit (UDFRoutine or ProcedureRoutine) corresponds
+// to FUNCTION or PROCEDURE; both bits set corresponds to ROUTINE, which
+// matches either kind.
+type CommentOnRoutine struct {
+	Routine     RoutineObj
+	RoutineType RoutineType
+	Comment     *string
+}
+
+// Format implements the NodeFormatter interface.
+func (n *CommentOnRoutine) Format(ctx *FmtCtx) {
+	switch n.RoutineType {
+	case ProcedureRoutine:
+		ctx.WriteString("COMMENT ON PROCEDURE ")
+	case UDFRoutine | ProcedureRoutine:
+		ctx.WriteString("COMMENT ON ROUTINE ")
+	default:
+		ctx.WriteString("COMMENT ON FUNCTION ")
+	}
+	ctx.FormatNode(&n.Routine)
+	ctx.WriteString(" IS ")
+	if n.Comment != nil {
+		// TODO(knz): Replace all this with ctx.FormatNode
+		// when COMMENT supports expressions.
+		if ctx.flags.HasFlags(FmtHideConstants) {
+			ctx.WriteString("'_'")
+		} else {
+			lexbase.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
+		}
+	} else {
+		ctx.WriteString("NULL")
+	}
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -105,7 +105,10 @@ const (
 	CommentOnColumnTag     = "COMMENT ON COLUMN"
 	CommentOnConstraintTag = "COMMENT ON CONSTRAINT"
 	CommentOnDatabaseTag   = "COMMENT ON DATABASE"
+	CommentOnFunctionTag   = "COMMENT ON FUNCTION"
 	CommentOnIndexTag      = "COMMENT ON INDEX"
+	CommentOnProcedureTag  = "COMMENT ON PROCEDURE"
+	CommentOnRoutineTag    = "COMMENT ON ROUTINE"
 	CommentOnSchemaTag     = "COMMENT ON SCHEMA"
 	CommentOnSequenceTag   = "COMMENT ON SEQUENCE"
 	CommentOnTableTag      = "COMMENT ON TABLE"
@@ -973,6 +976,26 @@ func (*CommentOnView) StatementType() StatementType { return TypeDDL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*CommentOnView) StatementTag() string { return CommentOnViewTag }
+
+// StatementReturnType implements the Statement interface.
+func (*CommentOnRoutine) StatementReturnType() StatementReturnType { return DDL }
+
+// StatementType implements the Statement interface.
+func (*CommentOnRoutine) StatementType() StatementType { return TypeDDL }
+
+// StatementTag returns the keyword the user wrote (FUNCTION, PROCEDURE, or
+// ROUTINE) so telemetry, log lines, and EXPLAIN reflect intent rather than
+// always showing FUNCTION.
+func (n *CommentOnRoutine) StatementTag() string {
+	switch n.RoutineType {
+	case ProcedureRoutine:
+		return CommentOnProcedureTag
+	case UDFRoutine | ProcedureRoutine:
+		return CommentOnRoutineTag
+	default:
+		return CommentOnFunctionTag
+	}
+}
 
 // StatementReturnType implements the Statement interface.
 func (*CommentOnSequence) StatementReturnType() StatementReturnType { return DDL }
@@ -2782,6 +2805,7 @@ func (n *CommentOnConstraint) String() string                 { return AsString(
 func (n *CommentOnDatabase) String() string                   { return AsString(n) }
 func (n *CommentOnSchema) String() string                     { return AsString(n) }
 func (n *CommentOnIndex) String() string                      { return AsString(n) }
+func (n *CommentOnRoutine) String() string                    { return AsString(n) }
 func (n *CommentOnSequence) String() string                   { return AsString(n) }
 func (n *CommentOnTable) String() string                      { return AsString(n) }
 func (n *CommentOnType) String() string                       { return AsString(n) }

--- a/pkg/sql/unimplemented.go
+++ b/pkg/sql/unimplemented.go
@@ -24,6 +24,19 @@ func (p *planner) AlterPolicy(ctx context.Context, n *tree.AlterPolicy) (planNod
 	return nil, makeUnimplementedLegacyError("ALTER POLICY")
 }
 
+func (p *planner) CommentOnRoutine(
+	ctx context.Context, n *tree.CommentOnRoutine,
+) (planNode, error) {
+	switch n.RoutineType {
+	case tree.ProcedureRoutine:
+		return nil, makeUnimplementedLegacyError("COMMENT ON PROCEDURE")
+	case tree.UDFRoutine | tree.ProcedureRoutine:
+		return nil, makeUnimplementedLegacyError("COMMENT ON ROUTINE")
+	default:
+		return nil, makeUnimplementedLegacyError("COMMENT ON FUNCTION")
+	}
+}
+
 func (p *planner) CommentOnSequence(
 	ctx context.Context, n *tree.CommentOnSequence,
 ) (planNode, error) {


### PR DESCRIPTION
**Stacked on top of cockroachdb#170415** ([rafiss/cockroach:comment-on-view](https://github.com/rafiss/cockroach/tree/comment-on-view)). When that PR merges, GitHub will auto-retarget this one to `cockroachdb:master` and the diff will narrow to just the function/procedure/routine commit.

Add PG-compatible `COMMENT ON FUNCTION`, `COMMENT ON PROCEDURE`, and
`COMMENT ON ROUTINE` statements, implemented in the declarative schema
changer. The legacy schema changer returns the standard "only implemented
in the declarative schema changer" error, mirroring the existing `COMMENT
ON TYPE` and `COMMENT ON VIEW`/`SEQUENCE` treatment.

The three keywords share a single `CommentOnRoutine` AST node
parameterized by `RoutineType`. ROUTINE matches either a function or a
procedure, mirroring PostgreSQL semantics. `ResolveRoutine` already
filters by `RoutineType`, so a kind mismatch (e.g. `COMMENT ON FUNCTION` on
a procedure) errors with `"X(args) is not a function/procedure"` exactly
like PG.

Unlike the VIEW/SEQUENCE work, which reused `TableComment` because views
and sequences share table descriptors, functions own their own
descriptor space. This commit therefore introduces a new
`scpb.FunctionComment` element, the corresponding `UpsertFunctionComment` /
`RemoveFunctionComment` ops, and a `GetFunctionComment` hook on the
`CommentGetter` interface so the planner can decompose an existing comment
when a function is later altered or dropped. Comments are stored using
the existing `catalogkeys.FunctionCommentType` (=6).

Privilege check is ownership rather than CREATE: functions have no
per-object CREATE privilege, and PG requires the routine owner. This
matches how `DROP`/`ALTER FUNCTION` already gate access.

`pg_catalog.pg_description` now also surfaces user comments on functions
(`classoid = pg_proc`, `objoid = function OID`), so
`obj_description(oid, 'pg_proc')` returns user-set comments. Predefined
comments on builtin functions, requested in the same issue, were already
exposed via `crdb_internal.kv_builtin_function_comments`; this commit just
adds a regression test that locks the behavior down. Builtin functions
remain off-limits for `COMMENT ON` writes.

Resolves: #44135
Epic: CRDB-60817

Release note (sql change): CockroachDB now supports the PostgreSQL
`COMMENT ON FUNCTION`, `COMMENT ON PROCEDURE`, and `COMMENT ON ROUTINE`
statements on user-defined functions and stored procedures. Comments
are visible via `pg_catalog.pg_description` and the
`obj_description(oid, 'pg_proc')` builtin. The argument list is required
when the routine name is overloaded and may be omitted otherwise.
Setting a comment to NULL removes it. The `COMMENT ON ROUTINE` form
accepts either a function or a procedure, matching PostgreSQL. Builtin
functions cannot be commented on; their predefined descriptions remain
readable through `obj_description`.